### PR TITLE
Remove observers on dealloc

### DIFF
--- a/Discovery/Discovery.m
+++ b/Discovery/Discovery.m
@@ -75,6 +75,11 @@
     return self;
 }
 
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+}
+
 -(void)setShouldAdvertise:(BOOL)shouldAdvertise {
     if(_shouldAdvertise == shouldAdvertise)
         return;


### PR DESCRIPTION
remove observers on dealloc. Otherwise the application crashes when a discovery object is deallocated and the app moves to the background
