### PR TITLE
Start advertise and discovery services on init

### DIFF
--- a/Discovery/Discovery.m
+++ b/Discovery/Discovery.m
@@ -56,14 +56,16 @@
         
         switch (startOption) {
             case DIStartAdvertisingAndDetecting:
-                _shouldAdvertise = YES;
-                _shouldDiscover = YES;
+                [self setShouldAdvertise:YES];
+                [self setShouldDiscover:YES];
                 break;
             case DIStartAdvertisingOnly:
-                _shouldAdvertise = YES;
+                [self setShouldAdvertise:YES];
+                [self setShouldDiscover:NO];
                 break;
             case DIStartDetectingOnly:
-                _shouldDiscover = YES;
+                [self setShouldAdvertise:NO];
+                [self setShouldDiscover:YES];
                 break;
             case DIStartNone:
             default:


### PR DESCRIPTION
Currently _shouldAdvertise and _shouldDiscover are being set directly, bypassing [setShouldAdvertise] and [setShouldDiscover]. This pull request calls the functions directly, making sure that the CBPeripheralManager and CBCentralManager are initialized in order for the services to start based off the startOption defined by the user.
